### PR TITLE
Fixed Mode Repositioning

### DIFF
--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
@@ -10,6 +10,7 @@ import net.runelite.api.Client;
 import net.runelite.api.ScriptID;
 import net.runelite.api.events.*;
 import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetID;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.chatbox.ChatboxPanelManager;
@@ -32,7 +33,7 @@ import java.util.function.IntPredicate;
 import java.util.stream.Collectors;
 
 @Slf4j
-@PluginDescriptor(name = "Fragment Presets")
+@PluginDescriptor(name = "Fragment Presets1")
 public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements MouseListener {
     @Inject
     private Client client;
@@ -287,6 +288,19 @@ public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements Mous
         }
 
         return mouseEvent;
+    }
+
+    @Subscribe
+    public void onWidgetLoaded(WidgetLoaded event) {
+        switch (event.getGroupId()) {
+            case WidgetID.FIXED_VIEWPORT_GROUP_ID:
+                this.sidebarOverlay.setIsFixedViewport(true);
+                break;
+            case WidgetID.RESIZABLE_VIEWPORT_OLD_SCHOOL_BOX_GROUP_ID:
+            case WidgetID.RESIZABLE_VIEWPORT_BOTTOM_LINE_GROUP_ID:
+                this.sidebarOverlay.setIsFixedViewport(false);
+                break;
+        }
     }
 
     @Override

--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
@@ -5,7 +5,6 @@ import com.google.gson.reflect.TypeToken;
 import com.google.inject.Provides;
 import javax.inject.Inject;
 
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.ScriptID;
 import net.runelite.api.events.*;
@@ -32,8 +31,7 @@ import java.util.List;
 import java.util.function.IntPredicate;
 import java.util.stream.Collectors;
 
-@Slf4j
-@PluginDescriptor(name = "Fragment Presets1")
+@PluginDescriptor(name = "Fragment Presets")
 public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements MouseListener {
     @Inject
     private Client client;

--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsSidebarOverlayPanel.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsSidebarOverlayPanel.java
@@ -1,7 +1,6 @@
 package io.tja.osrs.shattered_relics_fragment_presets;
 
 import com.google.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
@@ -15,7 +14,6 @@ import java.awt.*;
 import java.util.HashMap;
 import java.util.Map;
 
-@Slf4j
 public class ShatteredRelicsFragmentPresetsSidebarOverlayPanel extends OverlayPanel {
 
     private final Client client;

--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsSidebarOverlayPanel.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsSidebarOverlayPanel.java
@@ -1,9 +1,13 @@
 package io.tja.osrs.shattered_relics_fragment_presets;
 
 import com.google.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.*;
+import net.runelite.client.ui.overlay.components.ComponentConstants;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
 
@@ -11,6 +15,7 @@ import java.awt.*;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 public class ShatteredRelicsFragmentPresetsSidebarOverlayPanel extends OverlayPanel {
 
     private final Client client;
@@ -25,6 +30,8 @@ public class ShatteredRelicsFragmentPresetsSidebarOverlayPanel extends OverlayPa
     private final int SIDEBAR_RIGHT_MARGIN = 12;
     private final int SIDEBAR_TOP_MARGIN = 4;
 
+    private boolean isFixedWidth;
+
     private final Map<Preset, LineComponent> presetButtonComponents = new HashMap<>();
 
     @Inject
@@ -32,8 +39,6 @@ public class ShatteredRelicsFragmentPresetsSidebarOverlayPanel extends OverlayPa
             ShatteredRelicsFragmentPresetsPlugin plugin) {
         this.client = client;
         this.plugin = plugin;
-
-        panelComponent.setPreferredSize(new Dimension(SIDEBAR_WIDTH, 0));
         titleComponent = TitleComponent.builder().text("Presets").build();
         spacer = LineComponent.builder().build();
         newPresetButtonComponent = LineComponent.builder().left("+ Save as preset").build();
@@ -42,6 +47,18 @@ public class ShatteredRelicsFragmentPresetsSidebarOverlayPanel extends OverlayPa
         setPosition(OverlayPosition.DYNAMIC);
         setLayer(OverlayLayer.ALWAYS_ON_TOP);
         setPriority(OverlayPriority.MED);
+    }
+
+    public void setIsFixedViewport(boolean isFixedWidth) {
+        this.isFixedWidth = isFixedWidth;
+        if (isFixedWidth) {
+            Widget rootInterfaceWidget = client.getWidget(WidgetInfo.FIXED_VIEWPORT_ROOT_INTERFACE_CONTAINER);
+            panelComponent.setPreferredSize(new Dimension(rootInterfaceWidget.getOriginalWidth(), 0));
+            panelComponent.setBackgroundColor(new Color(70, 61, 50, 255));
+        } else {
+            panelComponent.setPreferredSize(new Dimension(SIDEBAR_WIDTH, 0));
+            panelComponent.setBackgroundColor(ComponentConstants.STANDARD_BACKGROUND_COLOR);
+        }
     }
 
     private void checkComponents() {
@@ -78,9 +95,16 @@ public class ShatteredRelicsFragmentPresetsSidebarOverlayPanel extends OverlayPa
         checkComponents();
 
         renderPresetSidebar(graphics);
-        panelComponent.setPreferredLocation(new Point(
-                plugin.fragmentWindowBounds.x - SIDEBAR_WIDTH - SIDEBAR_RIGHT_MARGIN,
-                plugin.fragmentWindowBounds.y + SIDEBAR_TOP_MARGIN));
+        if (isFixedWidth) {
+            Widget rootInterfaceWidget = client.getWidget(WidgetInfo.FIXED_VIEWPORT_ROOT_INTERFACE_CONTAINER);
+            panelComponent.setPreferredLocation(new Point(
+                    rootInterfaceWidget.getOriginalX(),
+                    rootInterfaceWidget.getOriginalY()));
+        } else {
+            panelComponent.setPreferredLocation(new Point(
+                    plugin.fragmentWindowBounds.x - SIDEBAR_WIDTH - SIDEBAR_RIGHT_MARGIN,
+                    plugin.fragmentWindowBounds.y + SIDEBAR_TOP_MARGIN));
+        }
 
         plugin.newPresetButtonBounds = newPresetButtonComponent.getBounds();
         plugin.deletePresetButtonBounds = deletePresetButtonComponent.getBounds();


### PR DESCRIPTION
Yet another PR concerned with fixed mode. This one solves for people who switch between fixed and resizable by hooking into the widgets that load when switching; those same events are fired on login, so the initial panel location/style will be correct.

The positioning for resizable is the same, fixed mode is overlaid on the inventory.

![image](https://user-images.githubusercontent.com/39996391/151069546-e2eb3d46-314e-4e10-919e-7445e98f33c7.png)

The fixed panel can currently hold 13 presets (11 if you don't want to overlay the logout button), it could be moved up over the minimap to hold more if necessary. 
![image](https://user-images.githubusercontent.com/39996391/151070223-9c75aa68-f107-4f42-81fb-f59609b412c3.png)


Another option is to allow the panel to be moved, but required a little more of a rework.

/e Here's what the panel looks like in resizable modes (unchanged):
![image](https://user-images.githubusercontent.com/39996391/151070551-bd575a76-f247-4be6-b647-56fa8764c6c6.png)

