### PR TITLE
Shift-Click Equip Fragments

### DIFF
--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsConfig.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsConfig.java
@@ -6,33 +6,43 @@ import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Range;
 
 @ConfigGroup("io.tja.osrs.shattered_relics_fragment_presets.v1")
-public interface ShatteredRelicsFragmentPresetsConfig extends Config
-{
-	public final String CONFIG_GROUP = "io.tja.osrs.shattered_relics_fragment_presets.v1";
+public interface ShatteredRelicsFragmentPresetsConfig extends Config {
+    public final String CONFIG_GROUP = "io.tja.osrs.shattered_relics_fragment_presets.v1";
 
-	public final String ALL_PRESETS = "all_presets";
+    public final String ALL_PRESETS = "all_presets";
 
-	@ConfigItem(keyName = "resizable_offset_x", name = "X Offset in resizable mode", description = "When in resizable" +
-			" mode, this offset will be manually applied to the X position of the preset pane")
-	@Range(min = Integer.MIN_VALUE, max = Integer.MAX_VALUE)
-	default int resizableOffsetX() {
-		return 0;
-	}
+    @ConfigItem(
+            keyName = "resizable_offset_x",
+            name = "X Offset in resizable mode",
+            description = "When in resizable mode, this offset will be manually applied to the X position of the " +
+                    "preset pane",
+            position = 0
+    )
+    @Range(min = Integer.MIN_VALUE, max = Integer.MAX_VALUE)
+    default int resizableOffsetX() {
+        return 0;
+    }
 
-	@ConfigItem(keyName = "resizable_offset_y", name = "Y Offset in resizable mode", description = "When in resizable" +
-			" mode, this offset will be manually applied to the Y position of the preset pane")
-	@Range(min = Integer.MIN_VALUE, max = Integer.MAX_VALUE)
-	default int resizableOffsetY() {
-		return 0;
-	}
-  
-  @ConfigItem(
-			keyName = "shitClickEquipFragment",
-			name = "Shift Click Equip Fragments",
-			description = "Allows the user to equip fragments by shift-clicking them. Note: There's currently no way to swap the \"unequip\" option.",
-			position = 1
-	)
-	default boolean shitClickEquipFragment() {
-		return true;
-  }
+    @ConfigItem(
+            keyName = "resizable_offset_y",
+            name = "Y Offset in resizable mode",
+            description = "When in resizable mode, this offset will be manually applied to the Y position of the " +
+                    "preset pane",
+            position = 1
+    )
+    @Range(min = Integer.MIN_VALUE, max = Integer.MAX_VALUE)
+    default int resizableOffsetY() {
+        return 0;
+    }
+
+    @ConfigItem(
+            keyName = "shift_click_Equip",
+            name = "Shift-click equip",
+            description = "Equip fragments by shift-clicking them. Note: There's currently no way to swap the " +
+                    "\"unequip\" option.",
+            position = 2
+    )
+    default boolean shitClickEquipFragment() {
+        return true;
+    }
 }

--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsConfig.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsConfig.java
@@ -2,6 +2,7 @@ package io.tja.osrs.shattered_relics_fragment_presets;
 
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup("io.tja.osrs.shattered_relics_fragment_presets.v1")
 public interface ShatteredRelicsFragmentPresetsConfig extends Config
@@ -9,4 +10,15 @@ public interface ShatteredRelicsFragmentPresetsConfig extends Config
 	public final String CONFIG_GROUP = "io.tja.osrs.shattered_relics_fragment_presets.v1";
 
 	public final String ALL_PRESETS = "all_presets";
+
+	@ConfigItem(
+			keyName = "shitClickEquipFragment",
+			name = "Shift Click Equip Fragments",
+			description = "Allows the user to equip fragments by shift-clicking them. Note: There's currently no way to swap the \"unequip\" option.",
+			position = 1
+	)
+	default boolean shitClickEquipFragment()
+	{
+		return true;
+	}
 }

--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsConfig.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsConfig.java
@@ -38,11 +38,11 @@ public interface ShatteredRelicsFragmentPresetsConfig extends Config {
     @ConfigItem(
             keyName = "shift_click_Equip",
             name = "Shift-click equip",
-            description = "Equip fragments by shift-clicking them. Note: There's currently no way to swap the " +
-                    "\"unequip\" option.",
+            description = "Equip fragments by shift-clicking them. Note: only works when clicking fragment text, not " +
+                    "fragment icons.",
             position = 2
     )
     default boolean shitClickEquipFragment() {
-        return true;
+        return false;
     }
 }

--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
@@ -5,8 +5,9 @@ import com.google.gson.reflect.TypeToken;
 import com.google.inject.Provides;
 import javax.inject.Inject;
 
-import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.KeyCode;
+import net.runelite.api.MenuEntry;
 import net.runelite.api.ScriptID;
 import net.runelite.api.events.*;
 import net.runelite.api.widgets.Widget;
@@ -31,7 +32,6 @@ import java.util.List;
 import java.util.function.IntPredicate;
 import java.util.stream.Collectors;
 
-@Slf4j
 @PluginDescriptor(name = "Fragment Presets")
 public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements MouseListener {
     @Inject
@@ -184,6 +184,10 @@ public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements Mous
             lastEquippedFragmentsForScrollFlow = equippedFragmentNames;
         }
 
+        if (config.shitClickEquipFragment() && !client.isMenuOpen() && client.isKeyPressed(KeyCode.KC_SHIFT)) {
+            swapFragmentsMenuEntry();
+        }
+
         showingFragments = true;
     }
 
@@ -287,6 +291,32 @@ public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements Mous
         }
 
         return mouseEvent;
+    }
+
+    private void swapFragmentsMenuEntry() {
+        /* This will only be called when the fragment window is open, we can do some simple filtering to ensure
+            we have the correct menu */
+        MenuEntry[] menuEntries = client.getMenuEntries();
+        if (menuEntries.length != 3) return;
+        int equipIndex = 1;
+        int viewIndex = 2;
+        // Sanity check "Cancel" option
+        int cancelIndex = 0;
+
+        boolean equipExists = (Text.removeTags(menuEntries[equipIndex].getOption()).equals("Equip"));
+        boolean viewExists = Text.removeTags(menuEntries[viewIndex].getOption()).equals("View");
+        boolean cancelExists = Text.removeTags(menuEntries[cancelIndex].getOption()).equals("Cancel");
+
+
+        if (equipExists && viewExists && cancelExists) {
+            MenuEntry leftClickEntry = menuEntries[equipIndex];
+            MenuEntry entry2 = menuEntries[viewIndex];
+
+            menuEntries[viewIndex] = leftClickEntry;
+            menuEntries[equipIndex] = entry2;
+
+            client.setMenuEntries(menuEntries);
+        }
     }
 
     @Override

--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
@@ -319,7 +319,6 @@ public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements Mous
         boolean viewExists = Text.removeTags(menuEntries[viewIndex].getOption()).equals("View");
         boolean cancelExists = Text.removeTags(menuEntries[cancelIndex].getOption()).equals("Cancel");
 
-
         if (equipExists && viewExists && cancelExists) {
             MenuEntry leftClickEntry = menuEntries[equipIndex];
             MenuEntry entry2 = menuEntries[viewIndex];


### PR DESCRIPTION
- Adds a config value for toggling feature
- Swaps the menu entry for `View` and `Equip` while holding shift.

Per [this](https://discord.com/channels/301497432909414422/419891709883973642/936236891706130543) RL discord conversation there's currently an issue/bug with swapping the menu entry for "Unequip".

Visually "Unequip" and view will swap, however upon clicking the fragment will be viewed and not unequipped.

Equip swap is working as intended.
![image](https://user-images.githubusercontent.com/39996391/151608808-3fb67955-2554-4126-8624-e19e3d68c198.png)
