### PR TITLE
Split presets across pages when there are more than a configurable limit

### DIFF
--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsConfig.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsConfig.java
@@ -75,7 +75,7 @@ public interface ShatteredRelicsFragmentPresetsConfig extends Config {
             description = "The number of presets to display per page",
             position = 5
     )
-    @Range(min = 1, max = Integer.MAX_VALUE)
+    @Range(min = -1, max = Integer.MAX_VALUE)
     default int pageSize() {
         return 10;
     }

--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsConfig.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsConfig.java
@@ -70,13 +70,24 @@ public interface ShatteredRelicsFragmentPresetsConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "page_size",
-            name = "Preset page size",
-            description = "The number of presets to display per page",
+            keyName = "resizable_page_size",
+            name = "Resizable mode page size",
+            description = "The number of presets to display per page in resizable mode (-1 to disable pagination)",
             position = 5
     )
     @Range(min = -1, max = Integer.MAX_VALUE)
-    default int pageSize() {
+    default int resizablePageSize() {
+        return 13;
+    }
+
+    @ConfigItem(
+            keyName = "fixed_page_size",
+            name = "Fixed mode page size",
+            description = "The number of presets to display per page in fixed mode (-1 to disable pagination)",
+            position = 5
+    )
+    @Range(min = -1, max = Integer.MAX_VALUE)
+    default int fixedPageSize() {
         return 10;
     }
 }

--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsConfig.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsConfig.java
@@ -68,4 +68,15 @@ public interface ShatteredRelicsFragmentPresetsConfig extends Config {
     default boolean showExtraButtons() {
         return false;
     }
+
+    @ConfigItem(
+            keyName = "page_size",
+            name = "Preset page size",
+            description = "The number of presets to display per page",
+            position = 5
+    )
+    @Range(min = 1, max = Integer.MAX_VALUE)
+    default int pageSize() {
+        return 10;
+    }
 }

--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
@@ -340,6 +340,7 @@ public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements Mous
         }
 
         allPresets.add(preset);
+        selectedPage = numberOfPages() - 1;
         persistPresets();
     }
 

--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
@@ -564,10 +564,11 @@ public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements Mous
     }
 
     public int pageSize() {
-        if (config.pageSize() < 1) {
+        int configVal = this.sidebarOverlay.isFixedViewport() ? config.fixedPageSize() : config.resizablePageSize();
+        if (configVal < 1) {
             return Integer.MAX_VALUE;
         }
-        return config.pageSize();
+        return configVal;
     }
 
     public boolean shouldRenderPreviousButton() {

--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
@@ -14,6 +14,7 @@ import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.chat.QueuedMessage;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.chatbox.ChatboxPanelManager;
 import net.runelite.client.input.MouseListener;
 import net.runelite.client.input.MouseManager;
@@ -141,11 +142,14 @@ public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements Mous
     public Rectangle deletePresetButtonBounds; // set by overlay
     public Rectangle importPresetButtonBounds; // set by overlay
     public Rectangle exportPresetButtonBounds; // set by overlay
+    public Rectangle previousPageButtonBounds; // set by overlay
+    public Rectangle nextPageButtonBounds; // set by overlay
 
     public List<Preset> allPresets = new ArrayList<>();
     public static Type PRESET_LIST_TYPE = new TypeToken<List<Preset>>() {
     }.getType();
     public Preset activePreset;
+    public int selectedPage = 0;
 
     @Override
     protected void startUp() throws Exception {
@@ -350,6 +354,7 @@ public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements Mous
                     allPresets.remove(activePreset);
                     activePreset = null;
                     persistPresets();
+                    clampPageToBounds();
                 })
                 .option("Nevermind!", () -> {
                 })
@@ -454,7 +459,19 @@ public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements Mous
             return mouseEvent;
         }
 
-        for (Preset p : allPresets) {
+        if (previousPageButtonBounds != null && previousPageButtonBounds.contains(mouseEvent.getPoint())) {
+            selectedPage -= 1;
+            mouseEvent.consume();
+            return mouseEvent;
+        }
+
+        if (nextPageButtonBounds != null && nextPageButtonBounds.contains(mouseEvent.getPoint())) {
+            selectedPage += 1;
+            mouseEvent.consume();
+            return mouseEvent;
+        }
+
+        for (Preset p : currentPageOfPresets()) {
             if (p.renderedBounds == null)
                 continue;
             if (p.renderedBounds.contains(mouseEvent.getPoint())) {
@@ -469,6 +486,20 @@ public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements Mous
         return mouseEvent;
     }
 
+    public List<Preset> currentPageOfPresets() {
+        return allPresets.subList(selectedPage * config.pageSize(), Math.min(selectedPage * config.pageSize() + config.pageSize(), allPresets.size()));
+    }
+
+    public int numberOfPages() {
+        return (int) Math.ceil((double) allPresets.size() / pageSize());
+    }
+
+    private void clampPageToBounds() {
+        if (selectedPage >= numberOfPages()) {
+            selectedPage = numberOfPages() - 1;
+        }
+    }
+
     @Subscribe
     public void onWidgetLoaded(WidgetLoaded event) {
         switch (event.getGroupId()) {
@@ -480,6 +511,11 @@ public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements Mous
                 this.sidebarOverlay.setIsFixedViewport(false);
                 break;
         }
+    }
+
+    @Subscribe
+    public void onConfigChanged(ConfigChanged event) {
+        clampPageToBounds();
     }
 
     @Override
@@ -522,6 +558,10 @@ public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements Mous
 
     public boolean shouldShowExtraButtons() {
         return config.showExtraButtons();
+    }
+
+    public int pageSize() {
+        return config.pageSize();
     }
 
     @Provides

--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
@@ -488,7 +488,7 @@ public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements Mous
     }
 
     public List<Preset> currentPageOfPresets() {
-        return allPresets.subList(selectedPage * config.pageSize(), Math.min(selectedPage * config.pageSize() + config.pageSize(), allPresets.size()));
+        return allPresets.subList(selectedPage * pageSize(), Math.min(selectedPage * pageSize() + pageSize(), allPresets.size()));
     }
 
     public int numberOfPages() {
@@ -562,6 +562,9 @@ public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements Mous
     }
 
     public int pageSize() {
+        if (config.pageSize() < 1) {
+            return Integer.MAX_VALUE;
+        }
         return config.pageSize();
     }
 

--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
@@ -461,13 +461,15 @@ public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements Mous
         }
 
         if (previousPageButtonBounds != null && previousPageButtonBounds.contains(mouseEvent.getPoint())) {
-            selectedPage -= 1;
+            if (shouldRenderPreviousButton()) selectedPage -= 1;
+            // consume the mouse event if the button is there but invisible (when there is a next button but no
+            // previous)
             mouseEvent.consume();
             return mouseEvent;
         }
 
         if (nextPageButtonBounds != null && nextPageButtonBounds.contains(mouseEvent.getPoint())) {
-            selectedPage += 1;
+            if (shouldRenderNextButton()) selectedPage += 1;
             mouseEvent.consume();
             return mouseEvent;
         }
@@ -567,6 +569,15 @@ public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements Mous
         }
         return config.pageSize();
     }
+
+    public boolean shouldRenderPreviousButton() {
+        return selectedPage > 0;
+    }
+
+    public boolean shouldRenderNextButton() {
+        return selectedPage < numberOfPages() - 1;
+    }
+
 
     @Provides
     ShatteredRelicsFragmentPresetsConfig provideConfig(ConfigManager configManager) {

--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsSidebarOverlayPanel.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsSidebarOverlayPanel.java
@@ -183,4 +183,8 @@ public class ShatteredRelicsFragmentPresetsSidebarOverlayPanel extends OverlayPa
     private boolean shouldRenderAnyPaginationButton() {
         return plugin.shouldRenderNextButton() || plugin.shouldRenderPreviousButton();
     }
+
+    public boolean isFixedViewport() {
+        return isFixedWidth;
+    }
 }

--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsSidebarOverlayPanel.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsSidebarOverlayPanel.java
@@ -120,19 +120,14 @@ public class ShatteredRelicsFragmentPresetsSidebarOverlayPanel extends OverlayPa
             plugin.exportPresetButtonBounds = null;
         }
 
-        if (shouldRenderPreviousButton()) {
+        if (shouldRenderAnyPaginationButton()) {
             Rectangle fullBounds = pageChangeButtonComponent.getBounds();
             plugin.previousPageButtonBounds = new Rectangle(fullBounds.x, fullBounds.y, fullBounds.width / 2, fullBounds.height);
-        } else {
-            plugin.previousPageButtonBounds = null;
-        }
-        if (shouldRenderNextButton()) {
-            Rectangle fullBounds = pageChangeButtonComponent.getBounds();
             plugin.nextPageButtonBounds = new Rectangle(fullBounds.x + fullBounds.width / 2, fullBounds.y, fullBounds.width / 2, fullBounds.height);
         } else {
+            plugin.previousPageButtonBounds = null;
             plugin.nextPageButtonBounds = null;
         }
-
 
         return super.render(graphics);
     }
@@ -141,15 +136,15 @@ public class ShatteredRelicsFragmentPresetsSidebarOverlayPanel extends OverlayPa
         titleComponent.setText(String.format("Presets (%d/%d)", plugin.selectedPage + 1, plugin.numberOfPages()));
         panelComponent.getChildren().add(titleComponent);
 
-        if (shouldRenderNextButton() || shouldRenderPreviousButton()) {
+        if (shouldRenderAnyPaginationButton()) {
             panelComponent.getChildren().add(pageChangeButtonComponent);
         }
-        if (shouldRenderPreviousButton()) {
+        if (plugin.shouldRenderPreviousButton()) {
             pageChangeButtonComponent.setLeft("<- Previous");
         } else {
             pageChangeButtonComponent.setLeft(null);
         }
-        if (shouldRenderNextButton()) {
+        if (plugin.shouldRenderNextButton()) {
             pageChangeButtonComponent.setRight("Next ->");
         } else {
             pageChangeButtonComponent.setRight(null);
@@ -185,11 +180,7 @@ public class ShatteredRelicsFragmentPresetsSidebarOverlayPanel extends OverlayPa
         }
     }
 
-    private boolean shouldRenderPreviousButton() {
-        return plugin.selectedPage > 0;
-    }
-
-    private boolean shouldRenderNextButton() {
-        return plugin.selectedPage < plugin.numberOfPages() - 1;
+    private boolean shouldRenderAnyPaginationButton() {
+        return plugin.shouldRenderNextButton() || plugin.shouldRenderPreviousButton();
     }
 }

--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsSidebarOverlayPanel.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsSidebarOverlayPanel.java
@@ -25,6 +25,7 @@ public class ShatteredRelicsFragmentPresetsSidebarOverlayPanel extends OverlayPa
     private final LineComponent deletePresetButtonComponent;
     private final LineComponent importPresetButtonComponent;
     private final LineComponent exportPresetButtonComponent;
+    private final LineComponent pageChangeButtonComponent;
 
     private final int SIDEBAR_WIDTH = 120;
     private final int SIDEBAR_RIGHT_MARGIN = 12;
@@ -45,6 +46,7 @@ public class ShatteredRelicsFragmentPresetsSidebarOverlayPanel extends OverlayPa
         deletePresetButtonComponent = LineComponent.builder().left("- Delete this preset").build();
         importPresetButtonComponent = LineComponent.builder().left("Import <- clipboard").build();
         exportPresetButtonComponent = LineComponent.builder().left("Export -> clipboard").build();
+        pageChangeButtonComponent = LineComponent.builder().build();
 
         setPosition(OverlayPosition.DYNAMIC);
         setLayer(OverlayLayer.ALWAYS_ON_TOP);
@@ -118,12 +120,43 @@ public class ShatteredRelicsFragmentPresetsSidebarOverlayPanel extends OverlayPa
             plugin.exportPresetButtonBounds = null;
         }
 
+        if (shouldRenderPreviousButton()) {
+            Rectangle fullBounds = pageChangeButtonComponent.getBounds();
+            plugin.previousPageButtonBounds = new Rectangle(fullBounds.x, fullBounds.y, fullBounds.width / 2, fullBounds.height);
+        } else {
+            plugin.previousPageButtonBounds = null;
+        }
+        if (shouldRenderNextButton()) {
+            Rectangle fullBounds = pageChangeButtonComponent.getBounds();
+            plugin.nextPageButtonBounds = new Rectangle(fullBounds.x + fullBounds.width / 2, fullBounds.y, fullBounds.width / 2, fullBounds.height);
+        } else {
+            plugin.nextPageButtonBounds = null;
+        }
+
+
         return super.render(graphics);
     }
 
     private void renderPresetSidebar(Graphics2D graphics) {
+        titleComponent.setText(String.format("Presets (%d/%d)", plugin.selectedPage + 1, plugin.numberOfPages()));
         panelComponent.getChildren().add(titleComponent);
+
+        if (shouldRenderNextButton() || shouldRenderPreviousButton()) {
+            panelComponent.getChildren().add(pageChangeButtonComponent);
+        }
+        if (shouldRenderPreviousButton()) {
+            pageChangeButtonComponent.setLeft("<- Previous");
+        } else {
+            pageChangeButtonComponent.setLeft(null);
+        }
+        if (shouldRenderNextButton()) {
+            pageChangeButtonComponent.setRight("Next ->");
+        } else {
+            pageChangeButtonComponent.setRight(null);
+        }
+
         panelComponent.getChildren().add(spacer);
+
         panelComponent.getChildren().add(newPresetButtonComponent);
         if (!plugin.allPresets.isEmpty()) {
             if (plugin.activePreset == null) {
@@ -137,9 +170,10 @@ public class ShatteredRelicsFragmentPresetsSidebarOverlayPanel extends OverlayPa
             panelComponent.getChildren().add(importPresetButtonComponent);
             panelComponent.getChildren().add(exportPresetButtonComponent);
         }
+
         panelComponent.getChildren().add(spacer);
 
-        for (Preset p : plugin.allPresets) {
+        for (Preset p : plugin.currentPageOfPresets()) {
             LineComponent c = presetButtonComponents.get(p);
             if (p == plugin.activePreset) {
                 c.setLeftColor(new Color(0, 255, 0, 255));
@@ -149,5 +183,13 @@ public class ShatteredRelicsFragmentPresetsSidebarOverlayPanel extends OverlayPa
             panelComponent.getChildren().add(c);
             p.renderedBounds = c.getBounds();
         }
+    }
+
+    private boolean shouldRenderPreviousButton() {
+        return plugin.selectedPage > 0;
+    }
+
+    private boolean shouldRenderNextButton() {
+        return plugin.selectedPage < plugin.numberOfPages() - 1;
     }
 }


### PR DESCRIPTION
### Problem
Especially in fixed mode, the amount of presets a user can create is de facto limited by the amount that can fit on the screen. Creating more than will fit simply results in the rest running off the screen. This was something I personally found annoying, but seems to be noticed by others as well, for example in https://github.com/SyntaxBlitz/osrs-shattered-relics-fragment-presets/issues/20.

### Solution
This PR seeks to fix this by adding pagination. Rather than displaying all presets at once, they will automatically be split across multiple pages, using a configurable page size to determine the number that show up per page. A user can use the "previous" and "next" buttons to go through these pages. This allows users to effectively manage larger numbers of presets than can fit on a single screen.

### Videos
#### Basic usage
https://user-images.githubusercontent.com/6942695/155866784-aa6270e4-f93c-4494-b07f-a7d851b76261.mp4

#### Adding a new preset when the last page is full
https://user-images.githubusercontent.com/6942695/155866790-351d2e7b-4f28-4064-a2ab-813b3fc56427.mp4

#### Edge case - deleting the last preset on the last page
https://user-images.githubusercontent.com/6942695/155866799-a46e85d4-15f7-4418-86ab-2b9da5ae8061.mp4

#### Changing the config while the menu is open
https://user-images.githubusercontent.com/6942695/155866805-bb517281-8b78-4770-8b2d-167eb8e19dc0.mp4

#### Resizable mode
https://user-images.githubusercontent.com/6942695/155866810-e1a0eb39-3f36-408f-83be-7730d886d2ae.mp4


