### PR TITLE
Cap number of pages to at least 1

### DIFF
--- a/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
+++ b/src/main/java/io/tja/osrs/shattered_relics_fragment_presets/ShatteredRelicsFragmentPresetsPlugin.java
@@ -494,7 +494,7 @@ public class ShatteredRelicsFragmentPresetsPlugin extends Plugin implements Mous
     }
 
     public int numberOfPages() {
-        return (int) Math.ceil((double) allPresets.size() / pageSize());
+        return Math.max((int) Math.ceil((double) allPresets.size() / pageSize()), 1);
     }
 
     private void clampPageToBounds() {


### PR DESCRIPTION
Raised in #22. plugin crashes when there are no presets, because there are 0 pages (so the selected page index gets set to -1). This PR just makes sure there's always at least one page